### PR TITLE
Change command caption to match style of Sublime Text commands

### DIFF
--- a/Commands.sublime-commands
+++ b/Commands.sublime-commands
@@ -1,6 +1,6 @@
 [
 	{
-		"caption": "MarkdownTableFormatter: format table",
+		"caption": "Markdown Table Formatter: Format Table",
 		"command": "markdown_table_format"
     }
 ]


### PR DESCRIPTION
This PR adds spaces between words, and capitalises each word of the command caption.

> Markdown Table Formatter: Format Table