### PR TITLE
Feat: support gfm style tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+*.pyc
+.pytest_cache

--- a/simple_markdown/table.py
+++ b/simple_markdown/table.py
@@ -1,6 +1,8 @@
 import re
 
 
+TABLE_PATTERN = re.compile(".*\|.*\r?\n[\s\t]*\|?(?: ?:?-+:? ?\| ?:?-+:? ?\|?)+(?:\r?\n.*\|.*)+")
+
 def enum(*sequential, **named):
     enums = dict(zip(sequential, range(len(sequential))), **named)
     from_string = dict((key, value) for key, value in enums.items())
@@ -16,8 +18,7 @@ def find_all(text):
     tables = []
     offset = 0
     while True:
-        pattern = ".*\|.*\r?\n[\s\t]*\|?(?::?-+:?\|:?-+:?\|?)+(?:\r?\n.*\|.*)+"
-        grp = re.search(pattern, text[offset:], re.MULTILINE)
+        grp = TABLE_PATTERN.search(text[offset:], re.MULTILINE)
         if grp is None:
             return tables
         tables.append((grp.start() + offset, grp.end() + offset))

--- a/tests/test.py
+++ b/tests/test.py
@@ -18,9 +18,9 @@ class test_markdown_table(unittest.TestCase):
         raw_table = """\
 |   Tables        | Are       | Cool  |
 |:-------------|-------------|-----:|
- | col 1 is      | left-aligned                                    | $1600 |  
-col 2 is      | centered|   $12  
-  | zebra stripes |       | are neat   $1 |  
+ | col 1 is      | left-aligned                                    | $1600 |
+col 2 is      | centered|   $12
+  | zebra stripes |       | are neat   $1 |
 || |$hello
 |    $2 |"""
 
@@ -69,9 +69,9 @@ a|"""
         junk_tables = """
 |   Tables        | Are       | Cool #1  |
 |-------------|:-------------:|:-----|
- | col 3 is      | right-aligned | $1600 |  
-col 2 is      ||   $12  
-  | zebra stripes|are neat|    $1 |  
+ | col 3 is      | right-aligned | $1600 |
+col 2 is      ||   $12
+  | zebra stripes|are neat|    $1 |
 || |$hello
 |    $2 |
 
@@ -81,9 +81,9 @@ and junk
 
 |   Tables        | Are       | Cool #2 |
 |-------------|:-------------:|:-----|
- | col 3 is      | right-aligned | $1600 |  
-col 2 is      ||   $12  
-  | zebra stripes | are neat                                |    $1 |  
+ | col 3 is      | right-aligned | $1600 |
+col 2 is      ||   $12
+  | zebra stripes | are neat                                |    $1 |
 || |$hello
 |    $2 |
 
@@ -98,6 +98,29 @@ is it?
 """
         offsets = Table.find_all(junk_tables)
         self.assertEqual(len(offsets), 3)
+
+    def test_gfm_table(self):
+        # test table with minimal form (#7)
+        gfm_minimal = """\
+| foo | bar | third |
+| :------- | --- | ---: |
+| 123 | 4567777789 | test |
+| a || |
+"""
+        offsets = Table.find_all(gfm_minimal)
+        self.assertEqual(len(offsets), 1)
+
+        expected = """\
+| foo | bar        | third |
+|:----|:-----------|------:|
+| 123 | 4567777789 |  test |
+| a   |            |       |"""
+
+        table = Table.format(gfm_minimal, margin=1, padding=0)
+        self.assertEqual(table, expected)
+
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -4,7 +4,6 @@
 import unittest
 
 import testpath
-import simple_markdown.table
 import simple_markdown.table as Table
 
 
@@ -97,7 +96,7 @@ and some | to test |
 if it's still working ||||||
 is it?
 """
-        offsets = simple_markdown.table.find_all(junk_tables)
+        offsets = Table.find_all(junk_tables)
         self.assertEqual(len(offsets), 3)
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are issues "finding the table" when spaces appeared in the "separator row".

See https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#tables for details