### PR TITLE
Support Chinese and English mixed typesetting alignment

### DIFF
--- a/simple_markdown/table.py
+++ b/simple_markdown/table.py
@@ -1,6 +1,12 @@
 import re
 
 
+def len_utf8(text):
+    lentext = len(text)
+    lentext_utf8 = len(text.encode('utf-8'))
+    length = int((lentext_utf8 - lentext)/2 + lentext)
+    return length
+
 def enum(*sequential, **named):
     enums = dict(zip(sequential, range(len(sequential))), **named)
     from_string = dict((key, value) for key, value in enums.items())
@@ -49,7 +55,7 @@ def format(raw_table, margin=1, padding=0, default_justify=Justify.LEFT):
     matrix[1] = [re.sub("[-. ]+","-", col) for col in matrix[1]]
 
     # determine each cell text size
-    text_width = [[len(col) for col in row] for row in matrix]
+    text_width = [[len_utf8(col) for col in row] for row in matrix]
     # determine column width (including space padding/margin)
     col_width = [max(size) + margin*2 + padding for size in zip(*text_width)]
 
@@ -74,7 +80,7 @@ def format(raw_table, margin=1, padding=0, default_justify=Justify.LEFT):
             continue
         for col_idx, col in enumerate(row):
             if justify[col_idx] == Justify.CENTER:
-                div, mod = divmod(col_width[col_idx] - len(col), 2)
+                div, mod = divmod(col_width[col_idx] - len_utf8(col), 2)
                 text = " "*div + col + " "*(div+mod)
                 line.append(text + "|")
                 continue


### PR DESCRIPTION
Need to be configured as a monospaced font [Ubuntu Mono](https://fonts.google.com/download?family=Ubuntu%20Mono): 

Preferences.sublime-settings - User

```json
{
	"font_face": "Ubuntu Mono",
	"font_size": 14
}
```

It was like this before the change：

<img width="461" alt="Screenshot at Apr 16 17-19-05" src="https://user-images.githubusercontent.com/15778311/56197675-e4542e00-606b-11e9-8b23-e0245432ee3f.png">

After the change is like this：

<img width="432" alt="Screenshot at Apr 16 17-19-50" src="https://user-images.githubusercontent.com/15778311/56197712-f930c180-606b-11e9-9c1c-a73f912e3207.png">
