### PR TITLE
Add support for variable last column widths in Markdown tables

### DIFF
--- a/MarkdownTableFormatter.sublime-settings
+++ b/MarkdownTableFormatter.sublime-settings
@@ -12,5 +12,9 @@
 	"padding": 0,
 
 	// how text should be justified when not specified [LEFT, RIGHT, CENTER]
-	"default_justification": "LEFT"
+	"default_justification": "LEFT",
+
+	// Whether the last column in tables must fit the widest content (set to
+	// "fixed") or can be variable width (set to "variable")
+	"last_column_width": "fixed"
 }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ There are two basic ways of using this plugin. Select what you want to format an
 
 ## Configuration
 
-```
+```json
 {
   // make plugin verbose in debug console
   "verbose": false,
@@ -31,7 +31,11 @@ There are two basic ways of using this plugin. Select what you want to format an
   "padding": 0,
 
   // how text should be justified when not specified [LEFT, RIGHT, CENTER]
-  "default_justification": "LEFT"
+  "default_justification": "LEFT",
+
+  // Whether the last column in tables must fit the widest content (set to
+  // "fixed") or can be variable width (set to "variable")
+  "last_column_width": "fixed"
 }
 ```
 

--- a/markdown_table_formatter.py
+++ b/markdown_table_formatter.py
@@ -21,6 +21,7 @@ class MarkdownTableFormatCommand(sublime_plugin.TextCommand):
         padding = settings.get("padding")
         justify = settings.get("default_justification")
         justify = markdown.table.Justify.from_string[justify]
+        last_column_width = settings.get("last_column_width")
 
         if verbose:
             log.setLevel(logging.DEBUG)
@@ -43,8 +44,9 @@ class MarkdownTableFormatCommand(sublime_plugin.TextCommand):
             for start, end in positions:
                 prev_table = text[start:end]
                 log.debug("table found:\n" + prev_table)
-                new_table = markdown.table.format(prev_table, margin, padding,
-                                                  justify)
+                new_table = markdown.table.format(prev_table,
+                                                  margin, padding, justify,
+                                                  last_column_width)
                 log.debug("formatted output:\n" + new_table)
 
                 # absolute original table position after some insertion/removal

--- a/simple_markdown/table.py
+++ b/simple_markdown/table.py
@@ -25,7 +25,8 @@ def find_all(text):
     return tables
 
 
-def format(raw_table, margin=1, padding=0, default_justify=Justify.LEFT):
+def format(raw_table, margin=1, padding=0, default_justify=Justify.LEFT,
+           last_column_width="fixed"):
     rows = raw_table.splitlines()
     # normalize markdown table, add missing leading/trailing '|'
     for idx, row in enumerate(rows):
@@ -52,6 +53,11 @@ def format(raw_table, margin=1, padding=0, default_justify=Justify.LEFT):
     text_width = [[len(col) for col in row] for row in matrix]
     # determine column width (including space padding/margin)
     col_width = [max(size) + margin*2 + padding for size in zip(*text_width)]
+    if last_column_width == "variable":
+        # modify the column width setting of last column to use use size of
+        # heading text of the last column instead of the size of the widest
+        # text of the last column
+        col_width[col_cnt-1] = text_width[0][-1] + margin*2 + padding
 
     # get each column justification or apply default
     justify = []

--- a/tests/test.py
+++ b/tests/test.py
@@ -66,6 +66,19 @@ a|"""
         table = Table.format(small, margin=1, padding=0)
         self.assertEqual(table, expected_small)
 
+        expected_table_variable = """\
+| Tables        | Are          | Cool |
+|:--------------|:-------------|-----:|
+| col 1 is      | left-aligned | $1600 |
+| col 2 is      | centered     |  $12 |
+| zebra stripes |              | are neat   $1 |
+|               |              | $hello |
+| $2            |              |      |"""
+
+        table = Table.format(raw_table, margin=1, padding=0,
+                             last_column_width="variable")
+        self.assertEqual(table, expected_table_variable)
+
     def test_find_all(self):
         junk_tables = """
 |   Tables        | Are       | Cool #1  |


### PR DESCRIPTION
Add support for variable last column widths in Markdown tables.

Often the last column in a Markdown table is the widest, and adding new rows with long pieces of text can cause the whole table to need reformatting, which isn't ideal in a Git diff view.

If the last column in a Markdown table can be variable width, the example given in https://github.com/bitwiser73/MarkdownTableFormatter/issues/22 is a single-line change, rather than a seven-line change.

Closes: https://github.com/bitwiser73/MarkdownTableFormatter/issues/22.